### PR TITLE
Update for Elixir 1.4+ function call syntax, and removed unsafe variable declaration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mimimix is Elixir code reloader. It watches the files in Elixir and Erlang direc
 2. Add to deps:
   ```elixir
   defp deps do
-    [{:mimimix, github: "evbogdanov/mimimix", only: :dev}]
+    [{:mimimix, github: "SeedyROM/mimimix", only: :dev}]
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mimimix is Elixir code reloader. It watches the files in Elixir and Erlang direc
 2. Add to deps:
   ```elixir
   defp deps do
-    [{:mimimix, github: "SeedyROM/mimimix", only: :dev}]
+    [{:mimimix, github: "evbogdanov/mimimix", only: :dev}]
   end
   ```
 

--- a/lib/mimimix.ex
+++ b/lib/mimimix.ex
@@ -18,11 +18,12 @@ defmodule Mimimix do
 
     def start_link do
       Process.send_after(__MODULE__, :poll_and_reload, 10000)
-      GenServer.start_link(__MODULE__, %State{}, name: Mimimix.Worker)
+      GenServer.start_link(__MODULE__, %State{last_mtime: nil}, name: Mimimix.Worker)
     end
 
     def handle_info(:poll_and_reload, state) do
       {dir, current_mtime} = get_mtime()
+
       state = if state.last_mtime != current_mtime do
         if dir == src() do
           IO.puts "Compiling Erlang..."
@@ -34,6 +35,7 @@ defmodule Mimimix do
         end
         %State{last_mtime: current_mtime}
       end
+
       Process.send_after(__MODULE__, :poll_and_reload, 1000)
       {:noreply, state}
     end

--- a/lib/mimimix.ex
+++ b/lib/mimimix.ex
@@ -18,13 +18,12 @@ defmodule Mimimix do
 
     def start_link do
       Process.send_after(__MODULE__, :poll_and_reload, 10000)
-      GenServer.start_link(__MODULE__, %State{last_mtime: nil}, name: Mimimix.Worker)
+      GenServer.start_link(__MODULE__, %State{}, name: Mimimix.Worker)
     end
 
     def handle_info(:poll_and_reload, state) do
       {dir, current_mtime} = get_mtime()
-
-      state = if state.last_mtime != current_mtime do
+      state = if state != nil and state.last_mtime != current_mtime do
         if dir == src() do
           IO.puts "Compiling Erlang..."
           Mix.Tasks.Compile.Erlang.run([]) # not enough

--- a/lib/mimimix.ex
+++ b/lib/mimimix.ex
@@ -22,17 +22,17 @@ defmodule Mimimix do
     end
 
     def handle_info(:poll_and_reload, state) do
-      {dir, current_mtime} = get_mtime
-      if state.last_mtime != current_mtime do
-        state = %State{last_mtime: current_mtime}
-        if dir == src do
+      {dir, current_mtime} = get_mtime()
+      state = if state.last_mtime != current_mtime do
+        if dir == src() do
           IO.puts "Compiling Erlang..."
           Mix.Tasks.Compile.Erlang.run([]) # not enough
-          scan(src) # extra work to do
+          scan(src()) # extra work to do
         else
           IO.puts "Compiling Elixir..."
           Mix.Tasks.Compile.Elixir.run(["--ignore-module-conflict"])
         end
+        %State{last_mtime: current_mtime}
       end
       Process.send_after(__MODULE__, :poll_and_reload, 1000)
       {:noreply, state}
@@ -42,12 +42,12 @@ defmodule Mimimix do
     get the latest modification time
     """
     def get_mtime do
-      mtime_lib = get_mtime lib
-      mtime_src = get_mtime src
+      mtime_lib = get_mtime lib()
+      mtime_src = get_mtime src()
       if mtime_lib > mtime_src do
-        {lib, mtime_lib}
+        {lib(), mtime_lib}
       else
-        {src, mtime_src}
+        {src(), mtime_src}
       end
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,9 +3,9 @@ defmodule Mimimix.Mixfile do
 
   def project do
     [app: :mimimix,
-     version: "0.0.1",
+     version: "0.0.2",
      elixir: "~> 1.0",
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
This solves all of the warnings that are currently being raised by the compiler since the change to the convention.